### PR TITLE
Handle strings or symbols as key for AllBlank

### DIFF
--- a/lib/reform/form/validate.rb
+++ b/lib/reform/form/validate.rb
@@ -5,12 +5,19 @@ module Reform::Form::Validate
       include Uber::Callable
 
       def call(form, options)
-        params = options[:input]
         # TODO: Schema should provide property names as plain list.
-        properties = options[:binding][:nested].definitions.collect { |dfn| dfn[:name] }
+        # ensure param keys are strings.
+        params = options[:input].each_with_object({}) { |(k, v), hash|
+          hash[k.to_s] = v
+        }
 
-        properties.each { |name| (!params[name].nil? && params[name] != "") and return false }
-        true # skip
+        # return false if any property inputs are populated.
+        options[:binding][:nested].definitions.each do |definition|
+          value = params[definition.name.to_s]
+          return false if (!value.nil? && value != '')
+        end
+
+        true # skip this property
       end
     end
   end

--- a/test/skip_if_test.rb
+++ b/test/skip_if_test.rb
@@ -71,4 +71,11 @@ class SkipIfAllBlankTest < BaseTest
     form.songs.size.must_equal 1
     form.songs[0].title.must_equal "Apathy"
   end
+
+  it do
+    form = AlbumForm.new(OpenStruct.new(songs: []))
+    form.validate(:songs => [{:title=>"", :length => ""}, {:title=>"Apathy"}]).must_equal true
+    form.songs.size.must_equal 1
+    form.songs[0].title.must_equal "Apathy"
+  end
 end


### PR DESCRIPTION
Ensure AllBlank returns correctly if forms have content, regardless of
type of key used.

Fixes https://github.com/apotonick/reform/issues/367#issuecomment-238605908

The explicit type conversion could be removed if the keys being passed in are guaranteed to be strings, but I'm not familiar enough with Dry schemas to attempt that currently.
