### PR TITLE
Add `Errors#count` and `#size` methods.

### DIFF
--- a/lib/reform/contract/errors.rb
+++ b/lib/reform/contract/errors.rb
@@ -49,4 +49,13 @@ class Reform::Contract::Errors
   def [](name)
     @errors[name] || []
   end
+
+  def size
+    @errors.values.flatten.size
+  end
+  alias :count :size
+
+  def empty?
+    size.zero?
+  end
 end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -97,6 +97,7 @@ class ErrorsTest < MiniTest::Spec
         :"songs.title"=> ["must be filled"],
         :"band.label.name"=>["must be filled"]
       })
+      form.errors.count.must_equal(4)
     end
   end
 
@@ -105,6 +106,7 @@ class ErrorsTest < MiniTest::Spec
     it do
       form.validate("title"=>"", "band"=>{"label"=>{:name => "Fat Wreck"}}).must_equal false
       form.errors.messages.must_equal({:title=>["must be filled"]})
+      form.errors.count.must_equal(1)
     end
   end
 
@@ -114,6 +116,7 @@ class ErrorsTest < MiniTest::Spec
 
     it { @result.must_equal false }
     it { form.errors.messages.must_equal({:"hit.title"=>["must be filled"]}) }
+    it { form.errors.count.must_equal(1) }
   end
 
 
@@ -122,6 +125,7 @@ class ErrorsTest < MiniTest::Spec
 
     it { @result.must_equal false }
     it { form.errors.messages.must_equal({:"songs.title"=>["must be filled"]}) }
+    it { form.errors.count.must_equal(1) }
   end
 
 
@@ -130,6 +134,7 @@ class ErrorsTest < MiniTest::Spec
 
     it { @result.must_equal false }
     it { form.errors.messages.must_equal({:"songs.title"=>["must be filled"], :"band.label.name"=>["must be filled"]}) }
+    it { form.errors.count.must_equal(2) }
   end
 
   describe "#validate with nested form using :base invalid" do
@@ -137,6 +142,7 @@ class ErrorsTest < MiniTest::Spec
       result = form.validate("songs"=>[{"title" => "Someday"}], "band" => {"name" => "Nickelback", "label" => {"name" => "Roadrunner Records"}})
       result.must_equal false
       form.errors.messages.must_equal({:"band.name"=>["you're a bad person"]})
+      form.errors.count.must_equal(1)
     end
   end
 
@@ -152,6 +158,10 @@ class ErrorsTest < MiniTest::Spec
     it { form.hit.title.must_equal "Sacrifice" }
     it { form.title.must_equal "Second Heat" }
     it { form.songs.first.title.must_equal "Heart Of A Lion" }
+    it do
+      form.errors.count.must_equal(0)
+      form.errors.empty?.must_equal(true)
+    end
   end
 
 


### PR DESCRIPTION
This improves compatibility with ActiveModel-style errors (which seems to be a goal of the gem, according to the docs and #345), and also makes integration with some gems other gems easier.

For example, some of the views for the devise authentication gem expect that an `errors` object will respond to `count`.

Obviously AM compatibility could be pushed further, but these changes are fairly innocuous and straightforwardly helpful.