### PR TITLE
Update stale comment about use of representable gem.

### DIFF
--- a/lib/reform/form.rb
+++ b/lib/reform/form.rb
@@ -31,7 +31,7 @@ module Reform
           options[:writeable] ||= options.delete(:writable)
         end
 
-        definition = super # let representable sort out inheriting of properties, and so on.
+        definition = super # let disposable and declarative gems sort out inheriting of properties, and so on.
         definition.merge!(deserializer: {}) unless definition[:deserializer] # always keep :deserializer per property.
 
         deserializer_options = definition[:deserializer]


### PR DESCRIPTION
Unless you've manually opted into it, the call to `super` here will go through the disposable and declarative gems, but not representable.

This is obviously a very minor change, but caused a bit of confusion for me when attempting to understand the source code. 

Of course, my understanding may be wrong, feel free to close the PR if it is.