### PR TITLE
added dry-v logic operator tests to demonstrate quirks in DSL

### DIFF
--- a/test/validation/dry_validation_test.rb
+++ b/test/validation/dry_validation_test.rb
@@ -237,6 +237,9 @@ class DryValidationLogicOperatorTest < MiniTest::Spec
       property :bar
 
       validation do
+        required(:foo).filled
+        required(:bar).filled
+
         rule(foobar: [:foo, :bar]) do |foo, bar|
           # syntax error when using "xor" alias
           foo.eql?("foobar") ^ bar.eql?("foobar")
@@ -254,7 +257,6 @@ class DryValidationLogicOperatorTest < MiniTest::Spec
 
     # invalid
     it do
-      # should pass but fails
       form.validate({ foo: "foobar", bar: "foobar"}).must_equal false
     end
   end

--- a/test/validation/dry_validation_test.rb
+++ b/test/validation/dry_validation_test.rb
@@ -228,6 +228,63 @@ class DryValidationDefaultGroupTest < Minitest::Spec
   end
 end
 
+class DryValidationLogicOperatorTest < MiniTest::Spec
+  OperatorClass = Struct.new(:foo, :bar)
+
+  describe "xor operator" do
+    class XorOperatorForm < TestForm
+      property :foo
+      property :bar
+
+      validation do
+        rule(foobar: [:foo, :bar]) do |foo, bar|
+          # syntax error when using "xor" alias
+          foo.eql?("foobar") ^ bar.eql?("foobar")
+        end
+      end
+    end
+
+    let(:form) { XorOperatorForm.new(OperatorClass.new) }
+
+    # valid
+    it do
+      form.validate({ foo: "foobar", bar: "barfoo"}).must_equal true
+      form.validate({ foo: "barfoo", bar: "foobar"}).must_equal true
+    end
+
+    # invalid
+    it do
+      # should pass but fails
+      form.validate({ foo: "foobar", bar: "foobar"}).must_equal false
+    end
+  end
+
+  describe "then operator" do
+    class ThenOperatorForm < TestForm
+      property :foo
+
+      validation do
+        # syntax error when using "then" alias
+        required(:foo) { filled? > int? }
+      end
+    end
+
+    let(:form) { ThenOperatorForm.new(OperatorClass.new) }
+
+    # valid
+    it do
+      form.validate({}).must_equal true
+      form.validate({ foo: 42 }).must_equal true
+    end
+
+    # invalid
+    it do
+      form.validate({ foo: "foobar" }).must_equal false
+      form.validate({ foo: 3.14 }).must_equal false
+    end
+  end
+end
+
 class ValidationGroupsTest < MiniTest::Spec
   describe "basic validations" do
     Session = Struct.new(:username, :email, :password, :confirm_password, :special_class)


### PR DESCRIPTION
Came across two issues:

- (named) logic operators half supported

Not sure if this is intended behaviour, because `and`, `or` can be used with no problem. Anyway, I meant to submit a failing test, but using `xor`, `then` results into syntax errors so you'll need to tweak the syntax manually (L:242, L:268).
 
- xor not exclusive

Hopefully the failing test speaks for itself (L:258).