### PR TITLE
Expose raw validation results

### DIFF
--- a/lib/reform/result.rb
+++ b/lib/reform/result.rb
@@ -7,7 +7,10 @@ module Reform
       def initialize(results, nested_results = []) # DISCUSS: do we like this?
         @results = results # native Result objects, e.g. `#<Dry::Validation::Result output={:title=>"Fallout", :composer=>nil} errors={}>`
         @failure = (results + nested_results).find(&:failure?) # TODO: test nested.
+        @nested_results = nested_results
       end
+
+      attr_reader :failure, :nested_results, :results
 
       def failure?; !!@failure end # rubocop:disable Style/DoubleNegation
 

--- a/lib/reform/result.rb
+++ b/lib/reform/result.rb
@@ -9,7 +9,7 @@ module Reform
         @failure = (results + nested_results).find(&:failure?) # TODO: test nested.
       end
 
-      def failure?; @failure  end
+      def failure?; !!@failure end # rubocop:disable Style/DoubleNegation
 
       def success?; !failure? end
 

--- a/test/validation/result_test.rb
+++ b/test/validation/result_test.rb
@@ -17,6 +17,16 @@ class ErrorsResultTest < Minitest::Spec
     it { Reform::Contract::Result.new([succeeded, succeeded]).success?.must_equal true }
   end
 
+  describe "Contract::Result#failure?" do
+    let(:failed) { MyResult.new(false) }
+    let(:succeeded) { MyResult.new(true) }
+
+    it { Reform::Contract::Result.new([failed, failed]).failure?.must_equal true }
+    it { Reform::Contract::Result.new([succeeded, failed]).failure?.must_equal true }
+    it { Reform::Contract::Result.new([failed, succeeded]).failure?.must_equal true }
+    it { Reform::Contract::Result.new([succeeded, succeeded]).failure?.must_equal false }
+  end
+
   describe "Contract::Result#errors" do
     let(:results) do
       [

--- a/test/validation/result_test.rb
+++ b/test/validation/result_test.rb
@@ -7,14 +7,12 @@ class ErrorsResultTest < Minitest::Spec
 
   # TODO: errors(args) not tested.
 
-  describe "Contract::Result#success?" do
+  describe "Contract::Result#failure" do
     let(:failed) { MyResult.new(false) }
     let(:succeeded) { MyResult.new(true) }
 
-    it { Reform::Contract::Result.new([failed, failed]).success?.must_equal false }
-    it { Reform::Contract::Result.new([succeeded, failed]).success?.must_equal false }
-    it { Reform::Contract::Result.new([failed, succeeded]).success?.must_equal false }
-    it { Reform::Contract::Result.new([succeeded, succeeded]).success?.must_equal true }
+    it { Reform::Contract::Result.new([succeeded, failed]).failure.must_equal failed }
+    it { Reform::Contract::Result.new([succeeded, succeeded], [failed]).failure.must_equal failed }
   end
 
   describe "Contract::Result#failure?" do
@@ -25,6 +23,31 @@ class ErrorsResultTest < Minitest::Spec
     it { Reform::Contract::Result.new([succeeded, failed]).failure?.must_equal true }
     it { Reform::Contract::Result.new([failed, succeeded]).failure?.must_equal true }
     it { Reform::Contract::Result.new([succeeded, succeeded]).failure?.must_equal false }
+  end
+
+  describe "Contract::Result#nested_results" do
+    let(:failed) { MyResult.new(false) }
+    let(:nested) { MyResult.new(true) }
+
+    it { Reform::Contract::Result.new([failed], [nested]).nested_results.must_equal [nested] }
+  end
+
+  describe "Contract::Result#results" do
+    let(:failed) { MyResult.new(false) }
+    let(:succeeded) { MyResult.new(true) }
+
+    it { Reform::Contract::Result.new([succeeded, failed]).results.must_equal [succeeded, failed] }
+    it { Reform::Contract::Result.new([succeeded, succeeded], [failed]).results.must_equal [succeeded, succeeded] }
+  end
+
+  describe "Contract::Result#success?" do
+    let(:failed) { MyResult.new(false) }
+    let(:succeeded) { MyResult.new(true) }
+
+    it { Reform::Contract::Result.new([failed, failed]).success?.must_equal false }
+    it { Reform::Contract::Result.new([succeeded, failed]).success?.must_equal false }
+    it { Reform::Contract::Result.new([failed, succeeded]).success?.must_equal false }
+    it { Reform::Contract::Result.new([succeeded, succeeded]).success?.must_equal true }
   end
 
   describe "Contract::Result#errors" do


### PR DESCRIPTION
As per @apotonick's request in #410 here is a PR to start the conversation about changes to Reform.

A couple things I noticed as I went through this.
- `#failure?` did not actually return a boolean value. It just returned whatever was in `@failure`. Since a new `#failure` method was being added, I updated `#failure?` to be more consistent with the expectation of a `?` method.
-  Is the `result.rb` line 9 is correct behavior? Should it instead be a `map`? As it is now, it's just going to find the first failure of the combined lists. Couldn't there be multiple?
