### PR TITLE
Raise error when skip_if and populator are used together 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 bundler_args: --without benchmarks tools
 rvm:

--- a/Rakefile
+++ b/Rakefile
@@ -2,16 +2,10 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"
 
-task default: %i[test rubocop]
+task default: %i[test]
 Rake::TestTask.new(:test) do |test|
   test.libs << "test"
   test.test_files = FileList["test/*_test.rb"] + FileList["test/validation/*_test.rb"]
-  test.verbose = true
-end
-
-Rake::TestTask.new(:test_rails) do |test|
-  test.libs << "test"
-  test.test_files = FileList["test/rails/*_test.rb"]
   test.verbose = true
 end
 

--- a/lib/reform/form.rb
+++ b/lib/reform/form.rb
@@ -1,5 +1,7 @@
 module Reform
   class Form < Contract
+    class InvalidOptionsCombinationError < StandardError; end
+
     def self.default_nested_class
       Form
     end
@@ -17,6 +19,12 @@ module Reform
       # Add macro logic, e.g. for :populator.
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       def property(name, options = {}, &block)
+        if (options.keys & %i[skip_if populator]).size == 2
+          raise InvalidOptionsCombinationError.new(
+            "[Reform] #{self}:property:#{name} Do not use skip_if and populator together, use populator with skip! instead"
+          )
+        end
+
         # if composition and inherited we also need this setting
         # to correctly inherit modules
         options[:_inherited] = options[:inherit] if options.key?(:on) && options.key?(:inherit)

--- a/test/skip_if_test.rb
+++ b/test/skip_if_test.rb
@@ -71,3 +71,16 @@ class SkipIfAllBlankTest < BaseTest
     form.songs[0].title.must_equal "Apathy"
   end
 end
+
+class InvalidOptionsCombinationTest < BaseTest
+  it do
+    assert_raises(Reform::Form::InvalidOptionsCombinationError) do
+      class AlbumForm < TestForm
+        collection :songs, skip_if: :all_blank, populator: -> {} do
+          property :title
+          property :length
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Let's notify the User that using `skip_if` and `populator` is kinda wrong and could create some issues.
This should "fix" https://github.com/trailblazer/reform/issues/434 