### PR TITLE
Warn user when validate is called more than ones

### DIFF
--- a/lib/reform/contract/validate.rb
+++ b/lib/reform/contract/validate.rb
@@ -1,5 +1,4 @@
 class Reform::Contract < Disposable::Twin
-  class DoubleValidateError < StandardError; end
   module Validate
     def initialize(*)
       # this will be removed in Reform 3.0. we need this for the presenting form, form builders
@@ -14,7 +13,7 @@ class Reform::Contract < Disposable::Twin
       # this is not cool and it will be removed in 3.0 where the API will not allow to call validate twice
       # or it will return the correct value even though it's called multiple times
       if already_validated
-        raise DoubleValidateError.new("[Reform] Do not run validate twice on the same form instance")
+        puts "WARN: [Reform] Running validate more than ones on the same instance can lead to silents errors (#{self})"
       end
 
       validate!(nil).success?

--- a/test/composition_test.rb
+++ b/test/composition_test.rb
@@ -85,7 +85,9 @@ class FormCompositionTest < MiniTest::Spec
   it { form.model[:song].must_equal song }
 
   it "creates Composition for you" do
+    form = RequestForm.new(song: song, requester: requester)
     form.validate("title" => "Greyhound", "name" => "Frenzal Rhomb").must_equal true
+    form = RequestForm.new(song: song, requester: requester)
     form.validate("title" => "", "name" => "Frenzal Rhomb").must_equal false
   end
 

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -52,6 +52,13 @@ class ContractValidateTest < MiniTest::Spec
     form.validate.must_equal false
     form.errors.messages.inspect.must_equal "{:name=>[\"must be filled\"], :\"songs.composer.name\"=>[\"must be filled\"]}"
   end
+
+  it 'raise DoubleValidateError if validate is called more than ones' do
+    form.validate.must_equal true
+    assert_raises(Reform::Contract::DoubleValidateError) do
+      form.validate
+    end
+  end
 end
 
 # no configuration results in "sync" (formerly known as parse_strategy: :sync).

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -53,10 +53,10 @@ class ContractValidateTest < MiniTest::Spec
     form.errors.messages.inspect.must_equal "{:name=>[\"must be filled\"], :\"songs.composer.name\"=>[\"must be filled\"]}"
   end
 
-  it 'raise DoubleValidateError if validate is called more than ones' do
+  it 'validate is called more than ones a warn message is shown' do
     form.validate.must_equal true
-    assert_raises(Reform::Contract::DoubleValidateError) do
-      form.validate
+    assert_output(/Running validate more than ones/) do
+      form.validate.must_equal true
     end
   end
 end


### PR DESCRIPTION
This will notify the User if a double validate happens (https://github.com/trailblazer/reform/issues/447) - discarded the solution to raise errors since it can break a lot of people code even though it's a wrong solution anyway.

Adding a note in the 3.0 project where we make sure to handle this in a better way