### PR TITLE
Allow to add an error after validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,8 @@ You can upgrade from 2.2.0 without worries.
 * When validating with dry-validation, we now pass a symbolized hash. We also replaced `Dry::Validation::Form` with `Schema` which won't coerce values where it shouldn't.
 * [private] `Group#call` API now is: `call(form, errors)`.
 * Removed `Form#valid?`.
-
 * In `:if` for validation groups, you now get a hash of result objects, not just true/false.
+* Allow adding a custom error AFTER validate has been already called
 
 
 ## 2.2.4

--- a/lib/reform/contract.rb
+++ b/lib/reform/contract.rb
@@ -2,6 +2,7 @@ module Reform
   # Define your form structure and its validations. Instantiate it with a model,
   # and then +validate+ this object graph.
   class Contract < Disposable::Twin
+    require "reform/contract/custom_error"
     require "disposable/twin/composition" # Expose.
     include Expose
 

--- a/lib/reform/contract/custom_error.rb
+++ b/lib/reform/contract/custom_error.rb
@@ -1,0 +1,35 @@
+module Reform
+  class Contract < Disposable::Twin
+    # a "fake" Dry schema object to add into the @results array
+    # super ugly hack required for 2.3.x version since we are creating
+    # a new Reform::Errors instance every time we call form.errors
+    class CustomError
+      def initialize(key, error_text, results)
+        @key        = key
+        @error_text = error_text
+        @errors     = {key => [error_text]}
+        @messages   = @errors
+        @hint       = {}
+        @results    = results
+
+        merge!
+      end
+
+      attr_reader :errors, :messages, :hint
+
+      def success?
+        false
+      end
+
+      def failure?
+        true
+      end
+
+      def merge!
+        @results.map(&:errors)
+                .detect { |hash| hash.key?(@key) }
+                .tap { |hash| hash.nil? ? @results << self : hash[@key] |= [@error_text] }
+      end
+    end
+  end
+end

--- a/lib/reform/errors.rb
+++ b/lib/reform/errors.rb
@@ -45,6 +45,14 @@ class Reform::Contract::Result::Errors
   def empty?
     messages.empty?
   end
+
+  # we need to delegate adding error to result because every time we call form.errors
+  # a new instance of this class is created so we need to update the @results array
+  # to be able to add custom errors here.
+  # This method will actually work only AFTER a validate call has been made
+  def add(key, error_test)
+    @result.add_error(key, error_test)
+  end
 end
 
 # Ensure that we can return Active Record compliant full messages when using dry

--- a/lib/reform/result.rb
+++ b/lib/reform/result.rb
@@ -19,6 +19,10 @@ module Reform
 
       def hints(*args);    filter_for(:hints, *args) end
 
+      def add_error(key, error_text)
+        CustomError.new(key, error_text, @results)
+      end
+
       private
 
       # this doesn't do nested errors (e.g. )

--- a/test/contract/custom_error_test.rb
+++ b/test/contract/custom_error_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class CustomerErrorTest < MiniTest::Spec
+  let(:key)            { :name }
+  let(:error_text)     { "text2" }
+  let(:starting_error) { [OpenStruct.new(errors: {title: ["text1"]})] }
+
+  let(:custom_error) { Reform::Contract::CustomError.new(key, error_text, @results) }
+
+  before { @results = starting_error }
+
+  it "base class structure" do
+    assert_equal custom_error.success?, false
+    assert_equal custom_error.failure?, true
+    assert_equal custom_error.errors, key => [error_text]
+    assert_equal custom_error.messages, key => [error_text]
+    assert_equal custom_error.hint, {}
+  end
+
+  describe "updates @results accordingly" do
+    it "add new key" do
+      custom_error
+
+      assert_equal @results.size, 2
+      errors = @results.map(&:errors)
+
+      assert_equal errors[0], starting_error.first.errors
+      assert_equal errors[1], custom_error.errors
+    end
+
+    describe "when key error already exists in @results" do
+      let(:key) { :title }
+
+      it "merge errors text" do
+        custom_error
+
+        assert_equal @results.size, 1
+
+        assert_equal @results.first.errors.values, [%w[text1 text2]]
+      end
+
+      describe "add error text is already" do
+        let(:error_text) { "text1" }
+
+        it 'does not create duplicates' do
+          custom_error
+
+          assert_equal @results.size, 1
+
+          assert_equal @results.first.errors.values, [%w[text1]]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The idea is to add in the `@results` instance variable an object which simulates a Dry schema object so any other part of the code should just work as before.
I have also added the possibility to add an error before actually running a validation (not sure if that makes sense but I don't see why it wouldn't).