### PR TITLE
Reintroduce valid?

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ You can upgrade from 2.2.0 without worries.
 * Reform now maintains a generic `Dry::Schema` class for global schema configuration. Can be overridden via `::validation`.
 * When validating with dry-validation, we now pass a symbolized hash. We also replaced `Dry::Validation::Form` with `Schema` which won't coerce values where it shouldn't.
 * [private] `Group#call` API now is: `call(form, errors)`.
-* Removed `Form#valid?`.
+* Modify `Form#valid?` - simply calls `validate({})`.
 * In `:if` for validation groups, you now get a hash of result objects, not just true/false.
 * Allow adding a custom error AFTER validate has been already called
 

--- a/lib/reform/validation.rb
+++ b/lib/reform/validation.rb
@@ -38,6 +38,10 @@ module Reform::Validation
     includer.extend(ClassMethods)
   end
 
+  def valid?
+    validate({})
+  end
+
   NoValidationLibraryError = Class.new(RuntimeError)
 end
 

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -205,6 +205,7 @@ class ValidateWithInternalPopulatorOptionTest < MiniTest::Spec
       "songs"  => [{"title" => "Fallout"}, {"title" => "Roxanne", "composer" => {"name" => "Sting"}}],
       "artist" => {"name" => "The Police"},
     ).must_equal true
+    form.valid?.must_equal true
 
     form.errors.messages.inspect.must_equal "{}"
 
@@ -230,6 +231,7 @@ class ValidateWithInternalPopulatorOptionTest < MiniTest::Spec
       "songs"  => [{"title" => "Fallout"}, {"title" => "Roxanne", "composer" => {"name" => ""}}],
       "artist" => {"name" => ""},
     ).must_equal false
+    form.valid?.must_equal false
 
     form.errors.messages.inspect.must_equal "{:name=>[\"must be filled\"], :\"songs.composer.name\"=>[\"must be filled\"], :\"artist.name\"=>[\"must be filled\"]}"
   end


### PR DESCRIPTION
Calls `validate({})`.

The aim of this method is to check if that specific Form instance is valid if model changes a new form instance MUST be created.
We have issues around about calling multiple times validate to the same instance and we know that has problems - this will be fixed in the 3.x