### PR TITLE
Allow to add errors before validate

### DIFF
--- a/lib/reform/contract/custom_error.rb
+++ b/lib/reform/contract/custom_error.rb
@@ -7,7 +7,7 @@ module Reform
       def initialize(key, error_text, results)
         @key        = key
         @error_text = error_text
-        @errors     = {key => [error_text]}
+        @errors     = {key => Array(error_text)}
         @messages   = @errors
         @hint       = {}
         @results    = results
@@ -28,7 +28,7 @@ module Reform
       def merge!
         @results.map(&:errors)
                 .detect { |hash| hash.key?(@key) }
-                .tap { |hash| hash.nil? ? @results << self : hash[@key] |= [@error_text] }
+                .tap { |hash| hash.nil? ? @results << self : hash[@key] |= Array(@error_text) }
       end
     end
   end

--- a/lib/reform/contract/validate.rb
+++ b/lib/reform/contract/validate.rb
@@ -22,6 +22,10 @@ class Reform::Contract < Disposable::Twin
       @result
     end
 
+    def custom_errors
+      @result.to_results.select { |result| result.is_a? Reform::Contract::CustomError }
+    end
+
     def validate!(name, pointers = [])
       # run local validations. this could be nested schemas, too.
       local_errors_by_group = Reform::Validation::Groups::Validate.(self.class.validation_groups, self).compact # TODO: discss compact
@@ -33,7 +37,7 @@ class Reform::Contract < Disposable::Twin
       nested_errors = validate_nested!(pointers_for_nested)
 
       # Result: unified interface #success?, #messages, etc.
-      @result = Result.new(local_errors_by_group + pointers, nested_errors)
+      @result = Result.new(custom_errors + local_errors_by_group + pointers, nested_errors)
     end
 
     private

--- a/lib/reform/result.rb
+++ b/lib/reform/result.rb
@@ -23,12 +23,16 @@ module Reform
         CustomError.new(key, error_text, @results)
       end
 
+      def to_results
+        @results
+      end
+
       private
 
       # this doesn't do nested errors (e.g. )
       def filter_for(method, *args)
         @results.collect { |r| r.public_send(method, *args) }
-                .inject({}) { |hsh, errs| hsh.merge(errs) }
+                .inject({}) { |hah, err| hah.merge(err) { |key, old_v, new_v| (new_v.is_a?(Array) ? (old_v |= new_v) : old_v.merge(new_v)) } }
                 .find_all { |k, v| # filter :nested=>{:something=>["too nested!"]} #DISCUSS: do we want that here?
                   if v.is_a?(Hash)
                     nested_errors = v.select { |attr_key, val| attr_key.is_a?(Integer) && val.is_a?(Array) && val.any? }

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -183,18 +183,21 @@ class ErrorsTest < MiniTest::Spec
   describe "#add" do
     let(:album_title) { nil }
     it do
+      form.errors.add(:before, "validate")
+      form.errors.add(:before, "validate 2")
+      form.errors.add(:title, "before validate")
       result = form.validate("songs" => [{"title" => "Someday"}], "band" => {"name" => "Nickelback", "label" => {"name" => "Roadrunner Records"}})
       result.must_equal false
-      form.errors.messages.must_equal(title: ["must be filled"], "band.name": ["you're a bad person"])
+      form.errors.messages.must_equal(before: ["validate", "validate 2"], title: ["before validate", "must be filled"], "band.name": ["you're a bad person"])
       # add a new custom error
       form.errors.add(:policy, "error_text")
-      form.errors.messages.must_equal(title: ["must be filled"], "band.name": ["you're a bad person"], policy: ["error_text"])
+      form.errors.messages.must_equal(before: ["validate", "validate 2"], title: ["before validate", "must be filled"], "band.name": ["you're a bad person"], policy: ["error_text"])
       # does not duplicate errors
       form.errors.add(:title, "must be filled")
-      form.errors.messages.must_equal(title: ["must be filled"], "band.name": ["you're a bad person"], policy: ["error_text"])
+      form.errors.messages.must_equal(before: ["validate", "validate 2"], title: ["before validate", "must be filled"], "band.name": ["you're a bad person"], policy: ["error_text"])
       # merge existing errors
       form.errors.add(:policy, "another error")
-      form.errors.messages.must_equal(title: ["must be filled"], "band.name": ["you're a bad person"], policy: ["error_text", "another error"])
+      form.errors.messages.must_equal(before: ["validate", "validate 2"], title: ["before validate", "must be filled"], "band.name": ["you're a bad person"], policy: ["error_text", "another error"])
     end
   end
 

--- a/test/validation/result_test.rb
+++ b/test/validation/result_test.rb
@@ -20,12 +20,14 @@ class ErrorsResultTest < Minitest::Spec
   describe "Contract::Result#errors" do
     let(:results) do
       [
+        MyResult.new(false, {length: ["no Int"]}),
         MyResult.new(false, {title: ["must be filled"], nested: {something: []}}),
-        MyResult.new(false, {length: ["no Int"]})
+        MyResult.new(false, {title: ["must be filled"], nested: {something: []}}),
+        MyResult.new(false, {title: ["something more"], nested: {something: []}})
       ]
     end
 
-    it { Reform::Contract::Result.new(results).errors.must_equal({title: ["must be filled"], length: ["no Int"]}) }
+    it { Reform::Contract::Result.new(results).errors.must_equal({title: ["must be filled", "something more"], length: ["no Int"]}) }
   end
 
   describe "Result::Pointer" do


### PR DESCRIPTION
In this is possible to have:
```
form.errors.add(:email, "already taken)
form.validate(email: "myemail@email.com")
form.errors.messages(email: ["already taken", "error from validation"])
```
or (maybe more possible):
```
form.validate(email: "my@email.com")
form.errors.add(:email, "something")
unless form.valid?
  flash[:error] = form.errors.messages
end
```
**An `add` error will never be clened up by `validate`.... validate a new form instance to have a fresh start**