### PR TITLE
[~] fix memory leak when use "dry-validation"

### DIFF
--- a/lib/reform/form/dry.rb
+++ b/lib/reform/form/dry.rb
@@ -46,8 +46,11 @@ module Reform::Form::Dry
 
         dynamic_options = { form: form }
         inject_options = schema_inject_params.merge(dynamic_options)
+        contract.new(inject_options).call(input_hash(form))
+      end
 
-        validator.build(inject_options, &block).call(input_hash(form))
+      def contract
+        @contract ||= Class.new(validator, &block)
       end
     end
   end

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -25,7 +25,7 @@ class ModuleInclusionTest < MiniTest::Spec
       params { required(:band).filled }
     end
 
-    include Dry::Types.module # allows using Types::* in module.
+    include Dry.Types(default: :nominal) # allows using Types::* in module.
     property :cool, type: Types::Params::Bool # test coercion.
   end
 


### PR DESCRIPTION
The issue was detected in ~~two~~ one places on each validation call:
1.    initialization of dry-validation contract
2.   ~~initialization new array with constants inside~~

to reproduce:
1) install gem https://github.com/SamSaffron/memory_profiler
2) go to the repository and profile memory consumption by ruby script "mem_leak.rb".
```bash
ruby-memory-profiler --pretty -m 5 mem_leak.rb
```

```ruby
# mem_leak.rb
require_relative "lib/reform"
require_relative "lib/reform/form/dry"

class TestForm < Reform::Form
  feature Reform::Form::Dry
end

Song = Struct.new(:title)
class Contr < TestForm
  validation do
    option :form
    params do
      required(:title).filled(min_size?: 2)
    end

    rule do
      if form == "hello"
        base.failure('creating events is allowed only on weekdays')
      end
    end
  end
end

form = Contr.new(Song.new(nil))

500.times do
  form.(title: "hello")
end
GC.start
```
3) download this PR and run it again.
---
here are results:

```
# before fix
{1:42}[2.7.2]~/reform:master ✗ ➭ ruby-memory-profiler --pretty -m 5 mem_leak.rb                                                                                                                       
Total allocated: 29.77 MB (261957 objects)                                                                                                                                                                                    
Total retained:  29.76 MB (261895 objects)  
...
# after fix
{1:42}[2.7.2]~/reform:master-fix-memory-leak ✗ ➭ ruby-memory-profiler --pretty -m 5 mem_leak.rb                                                                                                                 
Total allocated: 2.12 MB (20693 objects)                                                                                                                                                                                      
Total retained:  2.11 MB (20624 objects)
...
```

as a bonus, performance results:
```
# before
       user     system      total        real
   1.708815   0.072268   1.781083 (  1.782192)
# after 
       user     system      total        real
   0.181692   0.000599   0.182291 (  0.182303)
```