### PR TITLE
Upgrade `representable` and `disposable` to support ruby-3

### DIFF
--- a/lib/reform/form/dry.rb
+++ b/lib/reform/form/dry.rb
@@ -28,7 +28,7 @@ module Reform::Form::Dry
     class Group
       include InputHash
 
-      def initialize(**options)
+      def initialize(options)
         @validator = options.fetch(:contract, Contract)
         @schema_inject_params = options.fetch(:with, {})
       end
@@ -46,7 +46,7 @@ module Reform::Form::Dry
 
         dynamic_options = { form: form }
         inject_options = schema_inject_params.merge(dynamic_options)
-        contract.new(inject_options).call(input_hash(form))
+        contract.new(**inject_options).call(input_hash(form))
       end
 
       def contract

--- a/lib/reform/form/populator.rb
+++ b/lib/reform/form/populator.rb
@@ -7,7 +7,7 @@
 class Reform::Form::Populator
   def initialize(user_proc)
     @user_proc = user_proc # the actual `populator: ->{}` block from the user, via ::property.
-    @value     = Declarative::Option(user_proc, instance_exec: true, callable: Object) # we can now process Callable, procs, :symbol.
+    @value     = ::Representable::Option(user_proc) # we can now process Callable, procs, :symbol.
   end
 
   def call(input, options)
@@ -30,7 +30,7 @@ class Reform::Form::Populator
 
   def call!(options)
     form = options[:represented]
-    @value.(form, options) # Declarative::Option call.
+    @value.(exec_context: form, keyword_arguments: options) # Representable::Option call.
   end
 
   def handle_fail(twin, options)
@@ -66,7 +66,7 @@ class Reform::Form::Populator
       return @user_proc.new if @user_proc.is_a?(Class) # handle populate_if_empty: Class. this excludes using Callables, though.
 
       deprecate_positional_args(form, @user_proc, options) do
-        @value.(form, options)
+        @value.(exec_context: form, keyword_arguments: options)
       end
     end
 

--- a/lib/reform/form/prepopulate.rb
+++ b/lib/reform/form/prepopulate.rb
@@ -13,7 +13,7 @@ module Reform::Form::Prepopulate
   def prepopulate_local!(options)
     schema.each do |dfn|
       next unless block = dfn[:prepopulator]
-      Declarative::Option(block, instance_exec: true).(self, options)
+      ::Representable::Option(block).(exec_context: self, keyword_arguments: options)
     end
   end
 

--- a/lib/reform/form/validate.rb
+++ b/lib/reform/form/validate.rb
@@ -4,15 +4,15 @@ module Reform::Form::Validate
     class AllBlank
       include Uber::Callable
 
-      def call(form, options)
+      def call(input:, binding:, **)
         # TODO: Schema should provide property names as plain list.
         # ensure param keys are strings.
-        params = options[:input].each_with_object({}) { |(k, v), hash|
+        params = input.each_with_object({}) { |(k, v), hash|
           hash[k.to_s] = v
         }
 
         # return false if any property inputs are populated.
-        options[:binding][:nested].definitions.each do |definition|
+        binding[:nested].definitions.each do |definition|
           value = params[definition.name.to_s]
           return false if (!value.nil? && value != '')
         end

--- a/reform.gemspec
+++ b/reform.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency             "disposable",     ">= 0.4.2", "< 0.5.0"
-  spec.add_dependency             "representable",  ">= 2.4.0", "< 3.1.0"
+  spec.add_dependency             "disposable",     "~> 0.5.0"
+  spec.add_dependency             "representable",  ">= 3.1.1", "< 3.2.0"
   spec.add_dependency             "uber",           "< 0.2.0"
 
   spec.add_development_dependency "bundler"

--- a/test/populate_test.rb
+++ b/test/populate_test.rb
@@ -127,8 +127,8 @@ class PopulateWithCallableTest < Minitest::Spec
   class TitlePopulator
     include Uber::Callable
 
-    def call(form, options)
-      form.title = options[:fragment].reverse
+    def call(options)
+      options[:represented].title = options[:fragment].reverse
     end
   end
 

--- a/test/prepopulator_test.rb
+++ b/test/prepopulator_test.rb
@@ -51,7 +51,7 @@ class PrepopulatorTest < MiniTest::Spec
 
   # add to existing collection.
   it do
-    form = AlbumForm.new(OpenStruct.new(songs: [Song.new])).prepopulate!
+    form = AlbumForm.new(OpenStruct.new(songs: [Song.new])).prepopulate!(title: "Potemkin City Limits")
 
     assert_equal form.songs.size, 2
     assert_equal form.songs[0].model, Song.new


### PR DESCRIPTION
- Use `Representable::Option` instead of `Declarative::Option` to forward `keyword_arguments` as per ruby-3 standards.
- Display a warning while accepting `form` as an explicit positional argument in populator of type `Uber::Callable`. This will be deprecated in future release in order to make it identical with other type of populators (proc, method etc).