### PR TITLE
Loosen Representable dependency to allow versions < 4

### DIFF
--- a/reform.gemspec
+++ b/reform.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency             "disposable",     ">= 0.5.0", "< 1.0.0"
-  spec.add_dependency             "representable",  ">= 3.1.1", "< 3.2.0"
+  spec.add_dependency             "representable",  ">= 3.1.1", "< 4"
   spec.add_dependency             "uber",           "< 0.2.0"
 
   spec.add_development_dependency "bundler"

--- a/reform.gemspec
+++ b/reform.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "minitest-line"
-  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "multi_json"
   spec.add_development_dependency "rake"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@ require "minitest/autorun"
 require "representable/debug"
 require "declarative/testing"
 require "pp"
-require "pry-byebug"
 
 require "reform/form/dry"
 


### PR DESCRIPTION
This allows us to use representable 3.2.0 and other new minor versions.